### PR TITLE
Put package under @yext namespace for npmjs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "phonenumber-util",
+  "name": "@yext/phonenumber-util",
   "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "phonenumber-util",
+      "name": "@yext/phonenumber-util",
       "version": "0.1.0",
       "license": "BSD-3-Clause",
       "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "phonenumber-util",
+  "name": "@yext/phonenumber-util",
   "version": "0.1.0",
   "author": "bajohnson@hearsaycorp.com",
   "license": "BSD-3-Clause",


### PR DESCRIPTION
Right now, it's published to https://www.npmjs.com/package/phonenumber-util/ but we'll want it under @yext org ownership: https://www.npmjs.com/package/@yext/phonenumber-util/