### PR TITLE
Set sideEffects: false for better webpack treeshaking by consumer

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   "type": "module",
   "main": "src/index.js",
   "types": "src/index.d.ts",
+  "sideEffects": false,
   "repository": {
     "type": "git",
     "url": "git+https://github.com/hearsaycorp/phonenumber-util.git"


### PR DESCRIPTION
This util is (and will almost certainly remain) pure and basic JS.  Indicating as such to Webpack will allow consumers to more effectively prune during their compilation.  This isn't a big deal with what is here, but new features are coming that may add unnecessary bulk for those that are only interested in the core functionality.  This should hopefully allow us to continue to add functionality without burdening those not using it.

https://webpack.js.org/guides/tree-shaking/#mark-the-file-as-side-effect-free