### PR TITLE
Area code with mult timezones worked, but state with mult timezones was incorrect

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,7 +196,7 @@ Example output for Arizona:
 
 ```javascript
 import { findTimeFromAreaCode } from '@yext/phonenumber-util/geo';
-findTimeFromAreaCode('250');
+findTimeFromAreaCode('250', date); // A date object is optional, defaulting to the current time.
 ```
 
 Example output for British Columbia:

--- a/src/__tests__/geo.test.js
+++ b/src/__tests__/geo.test.js
@@ -37,6 +37,27 @@ const seattlePhone = {
   },
 };
 
+const portlandPhone = {
+  areaCodeHasMultipleTimezones: false,
+  daylightSavings: true,
+  estimatedTime: false,
+  isQuietHours: false,
+  isTCPAQuietHours: false,
+  localTime24Hour: '08:00:00',
+  localTimeReadable: '8:00:00 AM',
+  stateHasMultipleTimezones: true,
+  timezoneOffset: '-07:00',
+  state: {
+    name: 'Oregon',
+    code: 'OR',
+  },
+  region: {
+    name: 'United States',
+    code: 'US',
+    flag: '🇺🇸',
+  },
+};
+
 const arizonaPhoneJul = {
   areaCodeHasMultipleTimezones: false,
   daylightSavings: true,
@@ -250,6 +271,9 @@ describe('Provides general time information for the given phone number (US and C
     expect(
       findTimeFromAreaCode('206', new Date('2024-07-15T08:00:00')),
     ).toEqual(seattlePhone);
+    expect(
+      findTimeFromAreaCode('503', new Date('2024-07-15T08:00:00')),
+    ).toEqual(portlandPhone);
     expect(
       findTimeFromAreaCode('928', new Date('2024-07-15T08:00:00')),
     ).toEqual(arizonaPhoneJul);

--- a/src/geo.js
+++ b/src/geo.js
@@ -186,7 +186,8 @@ export function findTimeFromAreaCode(areaCode, date = new Date()) {
       returnTime.areaCodeHasMultipleTimezones = false;
     }
   } else {
-    returnTime.stateHasMultipleTimezones = false;
+    returnTime.stateHasMultipleTimezones =
+      !!STATES_WITH_MULTIPLE_TIMEZONES[stateName];
     returnTime.areaCodeHasMultipleTimezones = false;
     localOffset = STATE_TIMEZONES[stateName];
   }


### PR DESCRIPTION
Function `findTimeFromAreaCode` returns an object with a boolean of `stateHasMultipleTimezones`.  There was a bug that had that value based on whether the _area code_ had multiple timezones, not the broader state.  The `areaCodeHasMultipleTimezones` was still correctly reported.

Example: 503 area code in Portland, OR is entirely in the Pacific timezone.  `findTimeFromAreaCode` would return `stateHasMultipleTimezones: false` which is incorrect since 458 and 541 in Oregon have multiple timezones.