### PR TITLE
If a number is in an unexpected format, fallback to a standard (sanitized) number

### DIFF
--- a/src/__tests__/base.test.js
+++ b/src/__tests__/base.test.js
@@ -220,14 +220,19 @@ describe('Phone number pretty formatting', () => {
         format: findPhoneFormat({ regionCode: '57', e164: '+573211234567' }),
       },
       germany: {
-        e164: '+49 170 87654321',
+        e164: '+4917087654321',
         regionCode: '49',
         format: findPhoneFormat({ regionCode: '49', e164: '+4917087654321' }),
       },
       germanyAlt: {
-        e164: '+49 170 8765432',
+        e164: '+491708765432',
         regionCode: '49',
         format: findPhoneFormat({ regionCode: '49', e164: '+491708765432' }),
+      },
+      norwayUnexpected: {
+        e164: '+47174087654',
+        regionCode: '47',
+        format: findPhoneFormat({ regionCode: '47', e164: '+471740876543' }),
       },
     };
 
@@ -235,5 +240,9 @@ describe('Phone number pretty formatting', () => {
     expect(formatPhoneNumber(testNumbers.us)).toBe('(310) 349-6200');
     expect(formatPhoneNumber(testNumbers.colombia)).toBe('+57 321 123 4567');
     expect(formatPhoneNumber(testNumbers.germanyAlt)).toBe('+49 17 08765432');
+    // This looks like a Norwegian number, but doesn't match a known format.  In this case, we'll return a sanitized generic format.
+    expect(formatPhoneNumber(testNumbers.norwayUnexpected)).toBe(
+      '+47174087654',
+    );
   });
 });


### PR DESCRIPTION
We base the formatting off the number of digits in a given phone number matched against the number of digit placeholders in any available phone format for a given region.  An issue could arise when a yet-to-be-defined format is expected but not available, and forcing an overly-long phone number to be transposed into a number format, and leading digits could be omitted.  With this change, an unexpected format will return as a plain-text, unformatted number that has gone through sanitization so it can safely be rendered.  The one exception to this is region code 1, where adding the region code is uncommon, domestically.  Tests added to cover this corner-case.