### PR TITLE
Add comments to resource files

### DIFF
--- a/src/areaCodeList.js
+++ b/src/areaCodeList.js
@@ -1,3 +1,7 @@
+// The AREA_CODE_LIST is used in validation of NANP phone numbers.  If a number is passed to `isValidPhoneNumber` that is not found in this array, `false` will be returned.
+// If a new area code is added to this array, it must also be added to the AREA_CODES object in phoneCodes.js.
+// If a new area code is added and covers a region that has multiple timezones, it will need to be added to the STATES_WITH_MULTIPLE_TIMEZONES object in timezones.js.
+// If a new area code is added and covers a region that has portions that do and portions that do not adhere to daylight savings time, it will need to be added to the AREA_CODES_WITH_MULTIPLE_DAYLIGHT_SAVINGS object in daylightSavings.js.
 export const AREA_CODE_LIST = [
   '201',
   '202',

--- a/src/compliance.js
+++ b/src/compliance.js
@@ -1,3 +1,4 @@
+// Compliance settings are used to define quiet hours for the US (using TCPA) and Canada (using CRTC).
 export const TCPA_QUIET_HOURS = {
   start: 8,
   end: 21,
@@ -14,6 +15,7 @@ export const CRTC_QUIET_HOURS = {
   },
 };
 
+// The strings of CRTC_STATES must match the `name` field found within AREA_CODES object in phoneCodes.js.
 export const CRTC_STATES = [
   'Alberta',
   'British Columbia',

--- a/src/phoneCodes.js
+++ b/src/phoneCodes.js
@@ -422,7 +422,6 @@ export const AREA_CODES = {
     region: CANADA,
   },
   // Other North American Numbering Plan (NANP) Numbers
-  // These will return "United States, Canada" as the region, which is incorrect, but they follow the same standard.
   684: { region: { name: 'American Samoa', code: 'AS', flag: '🇦🇸' } },
   264: { region: { name: 'Anguilla', code: 'AI', flag: '🇦🇮' } },
   268: { region: { name: 'Antigua and Barbuda', code: 'AG', flag: '🇦🇬' } },

--- a/src/phoneFormats.js
+++ b/src/phoneFormats.js
@@ -1,3 +1,5 @@
+// For each region, provide a pretty format.  Some regions may have multiple formats, in which case an array can be used.  Each "x" will be replaced with a digit when the number of digits matches the number of "x"s in the format.
+// If no format is found with a correct matching length, a sanitized e164 is returned as a fall-back.
 export const PHONE_FORMATS = {
   1: '(xxx) xxx-xxxx', // United States
   7: '+x xxx xxx-xx-xx', // Russia

--- a/src/timezones.js
+++ b/src/timezones.js
@@ -1,3 +1,6 @@
+// Default timezone for each state, region or province.
+// While some region may have multiple timezones, we set the most common one here as a default.  See STATES_WITH_MULTIPLE_TIMEZONES below for references to exceptions within these regions.
+// Time calculations are only provided for US and Canada.
 export const STATE_TIMEZONES = {
   Alabama: '-06:00',
   Alaska: '-09:00',


### PR DESCRIPTION
In an effort to add clarity, ease of code auditing and encourage outside code contributions, add comments that explain exactly what the use of each resource file / object is and notes where changes in one area may require changes to other.

In order to lighten the base import load with tree-shaking, there is some redundancy between area code allow-list and the geo object (which is less commonly used) so new area codes will need to be added to each.