### PR TITLE
Correctly parse explicit US region phone numbers to derive correct href value

### DIFF
--- a/src/__tests__/base.test.js
+++ b/src/__tests__/base.test.js
@@ -130,6 +130,8 @@ describe('Phone number formatting', () => {
     expect(getPhoneParts('+33 7 56 78 90 12').formattedNumber).toBe(
       '+33 7 56 78 90 12',
     );
+    // US number with +1 prefix
+    expect(getPhoneParts('+17033354245').localNumber).toBe('3354245');
   });
 });
 
@@ -170,6 +172,12 @@ describe('Creation of phone links for href', () => {
         localNumber: '3496200',
         rawNumber: '(310) 349-6200',
       },
+      usIntl: {
+        regionCode: '1',
+        areaCode: '310',
+        localNumber: '3496200',
+        rawNumber: '+1 (310) 349-6200',
+      },
       intl: {
         regionCode: '49',
         localNumber: '1712345678',
@@ -182,6 +190,7 @@ describe('Creation of phone links for href', () => {
     expect(formatPhoneNumberLink(testNumbers.usAreaCode)).toBe(
       'tel:+13103496200',
     );
+    expect(formatPhoneNumberLink(testNumbers.usIntl)).toBe('tel:+13103496200');
     expect(formatPhoneNumberLink(testNumbers.intl)).toBe('tel:+491712345678');
   });
 });

--- a/src/base.js
+++ b/src/base.js
@@ -163,7 +163,7 @@ export const getPhoneParts = (phoneNumber) => {
       ) {
         phoneParts.regionCode = '1';
         phoneParts.areaCode = strippedPhoneNumber.slice(2, 5);
-        phoneParts.localNumber = strippedPhoneNumber.slice(5, 12);
+        phoneParts.localNumber = strippedPhoneNumber.slice(5);
       }
       // Otherwise, an intl number which may have 1, 2 or 3 digit region
       else if (

--- a/src/base.js
+++ b/src/base.js
@@ -162,8 +162,8 @@ export const getPhoneParts = (phoneNumber) => {
         strippedPhoneNumber.startsWith('+1')
       ) {
         phoneParts.regionCode = '1';
-        phoneParts.localNumber = strippedPhoneNumber.slice(2); // Strip out the "+1"
-        phoneParts.areaCode = phoneParts.localNumber.slice(0, 3); // Grab the area code
+        phoneParts.areaCode = strippedPhoneNumber.slice(2, 5);
+        phoneParts.localNumber = strippedPhoneNumber.slice(5, 12);
       }
       // Otherwise, an intl number which may have 1, 2 or 3 digit region
       else if (


### PR DESCRIPTION
Input of a +1 region code prefixed US number resulted in a malformed localNumber, which resulted in a malformed href value.

Input of "+13103525562" yielded:

Was:
```
[
  {
    "index": 0,
    "lastIndex": 12,
    "areaCode": "310",
    "e164": "+13103525562",
    "format": "(xxx) xxx-xxxx",
    "formattedNumber": "(310) 352-5562",
    "href": "tel:+13103103525562",
    "localNumber": "3103525562",
    "rawNumber": "+13103525562",
    "regionCode": "1",
    "timezoneOffset": "-07:00",
    "stateHasMultipleTimezones": false,
    "areaCodeHasMultipleTimezones": false,
    "daylightSavings": true,
    "estimatedTime": false,
    "state": {
      "name": "California",
      "code": "CA"
    },
    "region": {
      "name": "United States",
      "code": "US",
      "flag": "🇺🇸"
    },
    "localTimeReadable": "5:56:16 PM",
    "localTime24Hour": "17:56:16",
    "isTCPAQuietHours": false,
    "isQuietHours": false
  }
]
```

Now:
```
[
  {
    "index": 0,
    "lastIndex": 12,
    "areaCode": "310",
    "e164": "+13103525562",
    "format": "(xxx) xxx-xxxx",
    "formattedNumber": "(310) 352-5562",
    "href": "tel:+13103525562",
    "localNumber": "3525562",
    "rawNumber": "+13103525562",
    "regionCode": "1",
    "timezoneOffset": "-07:00",
    "stateHasMultipleTimezones": false,
    "areaCodeHasMultipleTimezones": false,
    "daylightSavings": true,
    "estimatedTime": false,
    "state": {
      "name": "California",
      "code": "CA"
    },
    "region": {
      "name": "United States",
      "code": "US",
      "flag": "🇺🇸"
    },
    "localTimeReadable": "5:53:16 PM",
    "localTime24Hour": "17:53:16",
    "isTCPAQuietHours": false,
    "isQuietHours": false
  }
]
```