### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -1,5 +1,8 @@
 name: Run pull request checks
 
+permissions:
+  contents: read
+
 on:
   pull_request:
     branches: ["main"]


### PR DESCRIPTION
Potential fix for [https://github.com/hearsaycorp/phonenumber-util/security/code-scanning/1](https://github.com/hearsaycorp/phonenumber-util/security/code-scanning/1)

To fix the issue, add a `permissions` block to the workflow. Since the workflow only reads repository contents and does not perform any write operations, the permissions should be limited to `contents: read`. This ensures that the `GITHUB_TOKEN` has the minimum required access.

The `permissions` block can be added at the root level of the workflow to apply to all jobs, or specifically to the `test` job. In this case, adding it at the root level is more concise and ensures consistency across all jobs.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
