### PR TITLE
[HERM-750] Replace aliases with hermes

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,2 +1,2 @@
 # The following aliases have approval permissions in this repo:
-* @imbrianj @mi4l @DerekWW @jperezhearsay @Bearbar00008 @jocruz-yext
+* @gmena @sergoh @ibiternas @andreshndz @gjakab4321 @Bearbar00008 @rrubioquintero @Marcelo-FC @jocruz-yext


### PR DESCRIPTION
## Summary
Replace the existing approval aliases in `CODEOWNERS` with a single `@hearsaycorp/hermes` owner line.

## Scope
- `CODEOWNERS`

## Testing
- [x] `git diff --check`